### PR TITLE
Add tests and more root files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
+# Custom
+.vscode/*
+
 # Byte-compiled / optimized / DLL files
 __pycache__/
 *.py[cod]

--- a/environment-dev.yml
+++ b/environment-dev.yml
@@ -5,3 +5,5 @@ dependencies:
 - python=3.7
 - pytest=5.1.2
 - black=19.3b0
+- mypy=0.720
+- flake8=3.7.8

--- a/environment-dev.yml
+++ b/environment-dev.yml
@@ -1,0 +1,7 @@
+name: pyprojroot-dev
+channels:
+- conda-forge
+dependencies:
+- python=3.7
+- pytest=5.1.2
+- black=19.3b0

--- a/pyprojroot/__init__.py
+++ b/pyprojroot/__init__.py
@@ -1,3 +1,3 @@
 from .pyprojroot import *
 
-__version__ = '0.1.0'
+__version__ = "0.1.0"

--- a/pyprojroot/pyprojroot.py
+++ b/pyprojroot/pyprojroot.py
@@ -12,7 +12,14 @@ def pyprojroot(p, proj_files):
 
 def here(
     rel_proj_path=".",
-    proj_files=[".git", ".here", "*.Rproj", "requirements.txt", "setup.py"],
+    proj_files=[
+        ".git",
+        ".here",
+        "*.Rproj",
+        "requirements.txt",
+        "setup.py",
+        ".dvc",
+    ],
 ):
     proj_path = pyprojroot(pl.Path(".").cwd(), proj_files)
 

--- a/pyprojroot/pyprojroot.py
+++ b/pyprojroot/pyprojroot.py
@@ -6,13 +6,15 @@ def pyprojroot(p, proj_files):
     for pf in proj_files:
         found = list(p.glob(pf))
         if len(found) > 0:
-            return(p)
+            return p
     return pyprojroot(p.parent, proj_files)
 
 
-def here(rel_proj_path='.',
-         proj_files=['.git', '.here', '*.Rproj', 'requirements.txt', 'setup.py']):
-    proj_path = pyprojroot(pl.Path('.').cwd(), proj_files)
+def here(
+    rel_proj_path=".",
+    proj_files=[".git", ".here", "*.Rproj", "requirements.txt", "setup.py"],
+):
+    proj_path = pyprojroot(pl.Path(".").cwd(), proj_files)
 
     pth = proj_path / rel_proj_path
 

--- a/pyprojroot/pyprojroot.py
+++ b/pyprojroot/pyprojroot.py
@@ -19,6 +19,7 @@ def here(
         "requirements.txt",
         "setup.py",
         ".dvc",
+        ".spyproject",
     ],
 ):
     proj_path = pyprojroot(pl.Path(".").cwd(), proj_files)

--- a/tests/test_pyprojroot.py
+++ b/tests/test_pyprojroot.py
@@ -2,4 +2,4 @@ from pyprojroot import __version__
 
 
 def test_version():
-    assert __version__ == '0.1.0'
+    assert __version__ == "0.1.0"

--- a/tests/test_pyprojroot.py
+++ b/tests/test_pyprojroot.py
@@ -1,5 +1,41 @@
-from pyprojroot import __version__
+from pyprojroot import __version__, here
+import os
+import pytest
+from pathlib import Path
 
 
 def test_version():
     assert __version__ == "0.1.0"
+
+
+@pytest.mark.parametrize(
+    "proj_file",
+    [
+        ".git",
+        ".here",
+        "my_project.Rproj",
+        "requirements.txt",
+        "setup.py",
+        ".dvc",
+    ],
+)
+@pytest.mark.parametrize("child_dir", ["stuff", "src", "data", "data/hello"])
+def test_here(tmpdir, proj_file, child_dir):
+    """
+    This test uses pytest's tmpdir facilities to create a simulated project
+    directory, and checks that the path is correct.
+    """
+    # Make proj_file
+    tmpdir = Path(tmpdir)
+    p = tmpdir / proj_file
+    with p.open("w") as fpath:
+        fpath.write("blah")
+
+    # Make child dirs
+    (tmpdir / child_dir).mkdir(parents=True)
+    os.chdir(tmpdir / child_dir)
+    assert os.getcwd() == str(tmpdir / child_dir)
+
+    # Check that proj
+    path = here()
+    assert path == tmpdir


### PR DESCRIPTION
Dude, this is a great package. I'm already using it in my own projects at work! Keeps things so much more sane.

I took the liberty of adding some tests. In particular, we test here that the root directories are found correctly.

Through modding the source code, I learned that I can use a `.here` file as well. That's amazeballs!

Also added `.spyproject`. Hope that helps. This would close #2.

Finally, some other utilities to help conda-based developers get started are added too.

In case you need confirmation on whether this works, at least it does on my computer:

```
$ pytest -k test_here
======================================================== test session starts =========================================================
platform darwin -- Python 3.6.7, pytest-4.4.1, py-1.7.0, pluggy-0.9.0
hypothesis profile 'default' -> database=DirectoryBasedExampleDatabase('/Users/ericmjl/github/software/pyprojroot/.hypothesis/examples')
rootdir: /Users/ericmjl/github/software/pyprojroot
plugins: remotedata-0.3.1, openfiles-0.3.1, doctestplus-0.2.0, arraydiff-0.2, hypothesis-4.17.2
collected 25 items / 1 deselected / 24 selected                                                                                      

tests/test_pyprojroot.py ........................                                                                              [100%]

============================================== 24 passed, 1 deselected in 0.22 seconds ===============================================
```