### PR TITLE
Update test with explicit naming, change import (ordering) and minor code refactor.

### DIFF
--- a/pyprojroot/pyprojroot.py
+++ b/pyprojroot/pyprojroot.py
@@ -1,9 +1,9 @@
 from typing import Tuple
-import pathlib as pl
+from pathlib import Path
 import warnings
 
 
-def py_project_root(path: pl.Path, project_files: Tuple) -> pl.Path:
+def py_project_root(path: Path, project_files: Tuple) -> Path:
     """
     Recursively searches for project files in the current working directory to find
     the project root of the python project.
@@ -32,14 +32,14 @@ def here(
         ".idea",
         ".vscode",
     ),
-) -> pl.Path:
+) -> Path:
     """
     Returns the directory relative to the projects root directory.
     :param project_files: list of files to track inside the project
     :param relative_project_path:
     :return: pathlib path
     """
-    project_path = py_project_root(pl.Path(".").cwd(), project_files)
+    project_path = py_project_root(Path(".").cwd(), project_files)
     path = project_path.joinpath(relative_project_path)
 
     if path.exists():

--- a/pyprojroot/pyprojroot.py
+++ b/pyprojroot/pyprojroot.py
@@ -19,27 +19,27 @@ def py_project_root(path: pl.Path, project_files: Tuple) -> pl.Path:
 
 
 def here(
-        relative_project_path='.',
-        project_files=(
-                ".git",
-                ".here",
-                ".Rproj",
-                "requirements.txt",
-                "setup.py",
-                ".dvc",
-                ".spyproject",
-                "pyproject.toml",
-                ".idea",
-                ".vscode"
-        ),
-    ) -> pl.Path:
+    relative_project_path=".",
+    project_files=(
+        ".git",
+        ".here",
+        "*.Rproj",
+        "requirements.txt",
+        "setup.py",
+        ".dvc",
+        ".spyproject",
+        "pyproject.toml",
+        ".idea",
+        ".vscode",
+    ),
+) -> pl.Path:
     """
     Returns the directory relative to the projects root directory.
     :param project_files: list of files to track inside the project
     :param relative_project_path:
     :return: pathlib path
     """
-    project_path = py_project_root(pl.Path('.').cwd(), project_files)
+    project_path = py_project_root(pl.Path(".").cwd(), project_files)
     path = project_path.joinpath(relative_project_path)
 
     if path.exists():

--- a/tests/test_pyprojroot.py
+++ b/tests/test_pyprojroot.py
@@ -1,7 +1,9 @@
-from pyprojroot import __version__, here
-import os
-import pytest
+from os import chdir
 from pathlib import Path
+
+import pytest
+
+from pyprojroot import __version__, here
 
 
 def test_version():
@@ -9,33 +11,26 @@ def test_version():
 
 
 @pytest.mark.parametrize(
-    "proj_file",
-    [
-        ".git",
-        ".here",
-        "my_project.Rproj",
-        "requirements.txt",
-        "setup.py",
-        ".dvc",
-    ],
+    "project_files",
+    (".git", ".here", "my_project.Rproj", "requirements.txt", "setup.py", ".dvc"),
 )
 @pytest.mark.parametrize("child_dir", ["stuff", "src", "data", "data/hello"])
-def test_here(tmpdir, proj_file, child_dir):
+def test_here(tmpdir, project_files, child_dir):
     """
     This test uses pytest's tmpdir facilities to create a simulated project
     directory, and checks that the path is correct.
     """
-    # Make proj_file
-    tmpdir = Path(tmpdir)
-    p = tmpdir / proj_file
-    with p.open("w") as fpath:
-        fpath.write("blah")
+    # Create project file
+    temp_dir = Path(tmpdir)
+    path = temp_dir / project_files
+    with path.open("w") as file_path:
+        file_path.write("blah")
 
-    # Make child dirs
-    (tmpdir / child_dir).mkdir(parents=True)
-    os.chdir(tmpdir / child_dir)
-    assert os.getcwd() == str(tmpdir / child_dir)
+    # Create child dirs
+    (temp_dir / child_dir).mkdir(parents=True)
+    chdir(temp_dir / child_dir)
+    assert Path().cwd() == (temp_dir / child_dir)
 
-    # Check that proj
-    path = here()
-    assert path == tmpdir
+    # Verify the project against current work directory
+    current_path = here()
+    assert current_path == temp_dir


### PR DESCRIPTION
Hello Daniël,

To correct for the Rproject filename lacking a wildcard character and failing the tests the pyprojectroot.py file was updated. Besides that the pathlib is made to explicitly import the Path function and also has been refactored in the functions. This should fix #8 .

The test code has been slightly refactored to also have more explicit comments and variables. 
Pathlib is utilized for path comparissons and the os module is only used for the chdir function, reducing the need to cast paths to string.
Last but not least, rearranged the imports, to keep things pretty.

Project is pushed from gitlab, so you'll see a different user in commits. 🤷‍♂  🍰 