### PR TITLE
Add CI and make `mypy --strict` compliant

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,0 +1,7 @@
+[flake8]
+extend-ignore = E203, E266, E501
+# line length is intentionally set to 80 here because black uses Bugbear
+# See https://github.com/psf/black/blob/master/docs/the_black_code_style.md#line-length for more details
+max-line-length = 80
+max-complexity = 18
+select = B,C,E,F,W,T4,B9

--- a/.github/workflows/python-package-conda.yml
+++ b/.github/workflows/python-package-conda.yml
@@ -1,0 +1,27 @@
+name: Python Package using Conda
+
+on: [push]
+
+jobs:
+  build-linux:
+    runs-on: ubuntu-latest
+    strategy:
+      max-parallel: 5
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up Python 3.8
+      uses: actions/setup-python@v2
+      with:
+        python-version: 3.8
+    - name: Install dev dependencies
+      run: |
+        $CONDA/bin/conda env update --file environment-dev.yml --name base
+    - name: Lint
+      run: |
+        $CONDA/bin/conda activate base
+        make lint
+    - name: Test with pytest
+      run: |
+        $CONDA/bin/conda activate base
+        make test

--- a/.github/workflows/python-package-conda.yml
+++ b/.github/workflows/python-package-conda.yml
@@ -19,9 +19,9 @@ jobs:
         $CONDA/bin/conda env update --file environment-dev.yml --name base
     - name: Lint
       run: |
-        $CONDA/bin/conda activate base
+        export PATH="${CONDA}/bin:${PATH}"
         make lint
     - name: Test with pytest
       run: |
-        $CONDA/bin/conda activate base
+        export PATH="${CONDA}/bin:${PATH}"
         make test

--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,23 @@
+.PHONY: deploy
 deploy:
 	rm -f dist/*
 	python setup.py sdist bdist_wheel
 	python -m twine upload dist/*
 
+.PHONY: test_install
 test_install:
 	python -m pip install --index-url https://pypi.org/simple/ --no-deps --upgrade pyprojroot
 
+.PHONY: lint
+lint:
+	python -m mypy --strict pyprojroot
+	python -m flake8 pyprojroot tests
+	python -m black --check --diff pyprojroot tests
+
+.PHONY: fmt
+fmt:
+	python -m black pyprojroot tests
+
+.PHONY: test
+test:
+	python -m pytest

--- a/environment-dev.yml
+++ b/environment-dev.yml
@@ -3,7 +3,7 @@ channels:
 - conda-forge
 dependencies:
 - python=3.7
-- pytest=5.1.2
+- pytest=6.1.1
 - black=19.3b0
 - mypy=0.720
-- flake8=3.7.8
+- flake8=3.8.4

--- a/pyprojroot/__init__.py
+++ b/pyprojroot/__init__.py
@@ -1,3 +1,4 @@
 from .pyprojroot import here, py_project_root  # noqa:F401
 
+__all__ = ["here", "py_project_root"]
 __version__ = "0.2.0"

--- a/pyprojroot/__init__.py
+++ b/pyprojroot/__init__.py
@@ -1,3 +1,3 @@
-from .pyprojroot import *
+from .pyprojroot import here, py_project_root  # noqa:F401
 
 __version__ = "0.2.0"

--- a/pyprojroot/pyprojroot.py
+++ b/pyprojroot/pyprojroot.py
@@ -3,7 +3,7 @@ from pathlib import Path
 import warnings
 
 
-def py_project_root(path: Path, project_files: Tuple) -> Path:
+def py_project_root(path: Path, project_files: Tuple[str, ...]) -> Path:
     """
     Recursively searches for project files in the current working directory
     to find the project root of the python project.
@@ -19,8 +19,8 @@ def py_project_root(path: Path, project_files: Tuple) -> Path:
 
 
 def here(
-    relative_project_path=".",
-    project_files=(
+    relative_project_path: str = ".",
+    project_files: Tuple[str, ...] = (
         ".git",
         ".here",
         "*.Rproj",
@@ -32,7 +32,7 @@ def here(
         ".idea",
         ".vscode",
     ),
-    warn=True
+    warn: bool = True,
 ) -> Path:
     """
     Returns the directory relative to the projects root directory.

--- a/setup.py
+++ b/setup.py
@@ -13,6 +13,7 @@ setuptools.setup(
     author_email="chendaniely@gmail.com",
     url="https://github.com/chendaniely/pyprojroot",
     packages=setuptools.find_packages(),
+    package_data={"pyprojroot": ["py.typed"]},
     classifiers=[
         "Programming Language :: Python :: 3",
         "License :: OSI Approved :: MIT License",

--- a/tests/test_pyprojroot.py
+++ b/tests/test_pyprojroot.py
@@ -7,7 +7,7 @@ from pyprojroot import __version__, here
 
 
 def test_version() -> None:
-    assert __version__ == "0.1.0"
+    assert __version__ == "0.2.0"
 
 
 @pytest.mark.parametrize(

--- a/tests/test_pyprojroot.py
+++ b/tests/test_pyprojroot.py
@@ -6,31 +6,28 @@ import pytest
 from pyprojroot import __version__, here
 
 
-def test_version():
+def test_version() -> None:
     assert __version__ == "0.1.0"
 
 
 @pytest.mark.parametrize(
-    "project_files",
+    "project_file",
     (".git", ".here", "my_project.Rproj", "requirements.txt", "setup.py", ".dvc"),
 )
-@pytest.mark.parametrize("child_dir", ["stuff", "src", "data", "data/hello"])
-def test_here(tmpdir, project_files, child_dir):
+@pytest.mark.parametrize("child_dir", ("stuff", "src", "data", "data/hello"))
+def test_here(tmp_path: Path, project_file: str, child_dir: str) -> None:
     """
-    This test uses pytest's tmpdir facilities to create a simulated project
+    This test uses pytest's tmp_path facilities to create a simulated project
     directory, and checks that the path is correct.
     """
     # Create project file
-    temp_dir = Path(tmpdir)
-    path = temp_dir / project_files
-    with path.open("w") as file_path:
-        file_path.write("blah")
+    (tmp_path / project_file).write_text("blah")
 
     # Create child dirs
-    (temp_dir / child_dir).mkdir(parents=True)
-    chdir(temp_dir / child_dir)
-    assert Path().cwd() == (temp_dir / child_dir)
+    child_path = tmp_path / child_dir
+    child_path.mkdir(parents=True)
+    chdir(child_path)
+    assert Path.cwd() == child_path
 
     # Verify the project against current work directory
-    current_path = here()
-    assert current_path == temp_dir
+    assert here() == tmp_path


### PR DESCRIPTION
Add CI though GitHub Actions.

This includes adding rules for `test` and `lint` to the Makefile and calling them in the added workflow. `fmt` has also been added to apply `black` formatting to the package and tests.

Additionally the linting checks against `mypy --strict`, `black` and `flake8`