### PR TITLE
fix #47 chore(pyprojroot): Fix make command

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,23 +1,23 @@
 .PHONY: deploy
 deploy:
 	rm -f dist/*
-	python setup.py sdist bdist_wheel
-	python -m twine upload dist/*
+	python3 setup.py sdist bdist_wheel
+	python3 -m twine upload dist/*
 
 .PHONY: test_install
 test_install:
-	python -m pip install --index-url https://pypi.org/simple/ --no-deps --upgrade pyprojroot
+	python3 -m pip install --index-url https://pypi.org/simple/ --no-deps --upgrade pyprojroot
 
 .PHONY: lint
 lint:
-	python -m mypy --strict src/pyprojroot
-	python -m flake8 src/pyprojroot tests
-	python -m black --check --diff src/pyprojroot tests
+	python3 -m mypy --strict src/pyprojroot
+	python3 -m flake8 src/pyprojroot tests
+	python3 -m black --check --diff src/pyprojroot tests
 
 .PHONY: fmt
 fmt:
-	python -m black src/pyprojroot tests
+	python3 -m black src/pyprojroot tests
 
 .PHONY: test
 test:
-	PYTHONPATH=src python -m pytest
+	PYTHONPATH=src python3 -m pytest


### PR DESCRIPTION
Since, on `Mac` you have to explicitly say `python3` instead of `python`, this PR changes the make command to use python3

Fixes #47 