### PR TITLE
CI trigger on main

### DIFF
--- a/.github/workflows/python-build-test.yml
+++ b/.github/workflows/python-build-test.yml
@@ -1,7 +1,10 @@
 name: Python package
 
-on: [push]
-
+on:
+  pull_request:
+  push:
+    branches:
+      - main
 jobs:
   build:
 


### PR DESCRIPTION
I  added this line in  python-build-test.yml:
``` on:
  pull_request:
  push:
    branches:
      - main
```
So the actions will be trigger during a pull request and a push on main

Fix #41 