### PR TITLE
Upgrade pytest to >2.6.5 so that it's compatible with python 3.10.

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,7 +32,7 @@ dev = [
     "build~=0.10.0",
 ]
 test = [
-    "pytest~=6.1.1",
+    "pytest>=6.2.5",
 ]
 
 [project.urls]

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,13 @@
+[tox]
+env_list =
+    py{37,38,39,310,311}
+minversion = 4.4.7
+
+[testenv]
+description = run the tests with pytest
+package = wheel
+wheel_build_env = .pkg
+deps =
+    pytest>=6.2.5
+commands =
+    pytest {tty:--color=yes} {posargs}


### PR DESCRIPTION
Also add a tox file to make it easier to test different python versions.