### PR TITLE
Remove unnecessary `__all__` from main module

### DIFF
--- a/src/pyprojroot/__init__.py
+++ b/src/pyprojroot/__init__.py
@@ -1,3 +1,4 @@
+# flake8: noqa: F401
 from .criterion import as_root_criterion, has_dir, has_file
 from .here import here
 from .root import find_root, find_root_with_reason

--- a/src/pyprojroot/__init__.py
+++ b/src/pyprojroot/__init__.py
@@ -1,13 +1,3 @@
 from .criterion import as_root_criterion, has_dir, has_file
 from .here import here
 from .root import find_root, find_root_with_reason
-
-
-__all__ = [
-    "as_root_criterion",
-    "find_root_with_reason",
-    "find_root",
-    "has_dir",
-    "has_file",
-    "here",
-]


### PR DESCRIPTION
__all__ is only required when using wildcard imports and to "hide" private parts of the API from wildcard imports