### PR TITLE
Deprecate `from pyprojroot import here`

### DIFF
--- a/src/pyprojroot/__init__.py
+++ b/src/pyprojroot/__init__.py
@@ -1,6 +1,14 @@
+from typing import deprecated as _deprecated
+
 from .criterion import as_root_criterion, has_dir, has_file
-from .here import here
 from .root import find_root, find_root_with_reason
+
+
+@_deprecated("Use `from pyprojroot.here import here` instead.")
+def here(*args, **kwargs):
+    from .here import here as h
+
+    h(*args, **kwargs)
 
 
 __all__ = [


### PR DESCRIPTION
This should be enough to mark `from pyprojroot import here` as deprecated. No such warning with `from pyprojroot.here import here`.